### PR TITLE
(WEB-43) Make patient view fit better on smaller screens

### DIFF
--- a/bower_components/patient.css
+++ b/bower_components/patient.css
@@ -18,20 +18,29 @@ body {
 }
 
 .graphJumbotron {
-  padding-top: 21px;
-  padding-bottom: 21px;
+  padding-top: 10px;
+  padding-bottom: 10px;
   padding-left: 21px;
   padding-right: 21px;
 }
 
 .graph-panel {
-  height: 150px;
+  height: 120px;
+}
+
+.well {
+  padding: 0px;
 }
 
 .number-well {
   width: 140px;
-  height: 120px;
-  font-size: 500%;
+  height: 90px;
+  padding: 0px;
+  font-size: 400%;
+}
+
+.number-well-text {
+  float: center;
 }
 
 .infoBox {
@@ -49,10 +58,10 @@ body {
 }
 
 .info-panel {
-  height: 321px;
+  height: 261px;
 }
 
 .list-group-item {
   padding-bottom: 5px;
-  font-size: 180%;
+  font-size: 150%;
 }

--- a/patient.html
+++ b/patient.html
@@ -61,7 +61,7 @@
               </div>
               <div class="pull-right">
                 <div class="well well-lg number-well">
-                  00
+                  <span class='number-well-text col-md-offset-3'>00</span>
                 </div>
               </div>
             </div>
@@ -74,7 +74,7 @@
               </div>
               <div class="pull-right">
                 <div class="well well-lg number-well">
-                  00
+                  <span class='number-well-text col-md-offset-3'>00</span>
                 </div>
               </div>
             </div>
@@ -87,7 +87,7 @@
               </div>
               <div class="pull-right">
                 <div class="well well-lg number-well">
-                  00
+                  <span class='number-well-text col-md-offset-3'>00</span>
                 </div>
               </div>
             </div>
@@ -100,7 +100,7 @@
               </div>
               <div class="pull-right">
                 <div class="well well-lg number-well">
-                  00
+                  <span class='number-well-text col-md-offset-3'>00</span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This commit reduces the size of most patient view components
to better fit smaller screens (even if they do have high resolutions).

Note that this commit is only part of WEB-43. Further work is needed
to ensure the components stretch correctly on larger displays.
