### PR TITLE
(WEB-51) Remove options dropdown from navbar

### DIFF
--- a/overview.html
+++ b/overview.html
@@ -46,20 +46,6 @@
                             </ul>
                         </li>
                     </ul>
-
-                    <!-- right side of navbar -->
-                    <ul class="nav navbar-nav navbar-right">
-                        <li class="dropdown">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Options <span class="caret"></span></a>
-                            <ul class="dropdown-menu" role="menu">
-                                <li><a href="#">Filters</a></li>
-                                <li><a href="#">High Contrast View</a></li>
-                                <li><a href="#">Something else here</a></li>
-                                <li class="divider"></li>
-                                <li><a href="#">Separated link</a></li>
-                            </ul>
-                        </li>
-                    </ul>
                 </div>
                 <!-- /.navbar-collapse -->
             </div>

--- a/patient.html
+++ b/patient.html
@@ -42,20 +42,6 @@
                 </ul>
               </li>
           </ul>
-
-          <!-- right side of navbar -->
-          <ul class="nav navbar-nav navbar-right">
-            <li class="dropdown">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Options <span class="caret"></span></a>
-              <ul class="dropdown-menu" role="menu">
-                <li><a href="#">Filters</a></li>
-                <li><a href="#">High Contrast View</a></li>
-                <li><a href="#">Something else here</a></li>
-                <li class="divider"></li>
-                <li><a href="#">Separated link</a></li>
-              </ul>
-            </li>
-          </ul>
         </div><!-- /.navbar-collapse -->
       </div><!-- /.container-fluid -->
     </nav>


### PR DESCRIPTION
The options dropdown functionality was scrapped, and
so is no longer necessary. This commit removes it from
the navigation bar.
