### PR TITLE
(Web-65) Fix Date in alert to be only time

### DIFF
--- a/overview.css
+++ b/overview.css
@@ -12,6 +12,7 @@ body {
 
 .alert_box {
     margin-right:30px;
+    height:521px;
     background-color:white;
 }
 

--- a/smoothie_graphs/overview_graphs.js
+++ b/smoothie_graphs/overview_graphs.js
@@ -26,6 +26,7 @@ function ecg_graph(eb) {
         eb.registerHandler(channelName, function(msg) {
           currentBuffers[channelName].push(msg.data);
         });
+         
       }
     )
   }
@@ -97,7 +98,18 @@ function ecg_graph(eb) {
         this.id = msg.patient_id;
         this.interval = msg.interval;
         this.signame = msg.signame;
-        
+
+        var alert_hours = alert_time.getHours();
+        var alert_mins = alert_time.getMinutes();
+        if (alert_hours < 10) {
+           alert_hours = "0" + alert_hours;
+        }
+        if (alert_mins < 10) {
+           alert_mins = "0" + alert_mins;
+        }
+        this.alert_time = alert_hours + ":" + alert_mins;
+     
+
         $.getJSON('/patients.json', function(data) {
             self.name = data['patients'][(self.id)]['name'];
             self.age =  data['patients'][(self.id)]['age'];


### PR DESCRIPTION
Changed the date in the alert pop up to only be the time, rather than the entire date and time zone.
