### PR TITLE
(WEB-71) Turn off alerts only turns off popups

### DIFF
--- a/smoothie_graphs/overview_graphs.js
+++ b/smoothie_graphs/overview_graphs.js
@@ -166,16 +166,16 @@ function ecg_graph(eb) {
                     </table>\
                 </div>\
             ");
-            if (alertOff == 0) {
-               $('#alertModal').modal('show');
-            }
+             $('#alertModal').modal('show');
         }
 
         $.getJSON('http://api.s-pi-demo.com/patients', function(data) {
             Alert.name = data[(Alert.id)]['name'];
             Alert.age =  data[(Alert.id)]['age'];
             Alert.bed =  data[(Alert.id)]['bed'];
-            render_alert();
+            if (alertOff == 0) {
+              render_alert();
+            }
 
             counter = counter +1;
 


### PR DESCRIPTION
Using the turn off alerts option will only turn off the popup of the alerts, instead of blocking the alerts entirely. When off the alerts will still update on the side and can now open the alert window when clicked.
